### PR TITLE
fix: upgrade build JVM to Java 17

### DIFF
--- a/.github/workflows/github-actions-java8.yml
+++ b/.github/workflows/github-actions-java8.yml
@@ -51,12 +51,12 @@ jobs:
       - name: Checkout repository code
         uses: actions/checkout@v6
 
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          java-version: "8"
+          java-version: "17"
           distribution: "zulu"
-          check-latest: true  # Get the latest Java 8 patch version
+          check-latest: true
 
       - name: Validate Gradle wrapper
         uses: gradle/actions/wrapper-validation@v4

--- a/.github/workflows/github-actions-java8.yml
+++ b/.github/workflows/github-actions-java8.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Run OWASP dependency check
         if: matrix.os == 'windows-latest'  # Only run on one platform
-        run: ./gradlew dependencyCheckAnalyze --no-daemon --stacktrace --continue
+        run: ./gradlew dependencyCheckAnalyze --no-daemon --stacktrace
         continue-on-error: true  # Don't fail the build if dependency check has issues
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,5 +2,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- Change CI from `java-version: "8"` to `"17"` so Gradle can load `dependency-check-gradle:12.2.2` and Kotlin 2.4.0, both of which require JVM 11+
- Production output bytecode is unchanged — `sourceCompatibility = JavaVersion.VERSION_1_8` and `JvmTarget.JVM_1_8` in `build.gradle.kts` remain in place

## Test plan
- [ ] CI build completes successfully on all three platforms
- [ ] Produced JAR runs on Java 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)